### PR TITLE
Players can use animations while muted

### DIFF
--- a/module_constants.py
+++ b/module_constants.py
@@ -595,6 +595,8 @@ max_hit_points_percent                = 200
 
 admin_restock_amount                  = 5 # amount admin restocks pile by for each use
 
+animations_while_muted                = 1 # can players use animations while muted?
+
 all_items_begin = "itm_tattered_headcloth"
 all_items_end = "itm_all_items_end"
 

--- a/module_scripts.py
+++ b/module_scripts.py
@@ -13838,6 +13838,10 @@ scripts.extend([
 
     (assign, ":test_passed", 0),
     (try_begin),
+      (player_get_is_muted, ":is_muted", ":player_id"),
+      (this_or_next|eq, ":is_muted", 0),
+      (this_or_next|neg|multiplayer_is_server),
+      (eq, animations_while_muted, 1),
       (player_get_agent_id, ":agent_id", ":player_id"),
       (agent_is_active, ":agent_id"),
       (agent_is_alive, ":agent_id"),

--- a/module_scripts.py
+++ b/module_scripts.py
@@ -13838,7 +13838,6 @@ scripts.extend([
 
     (assign, ":test_passed", 0),
     (try_begin),
-      (neg|multiplayer_is_server),
       (player_get_agent_id, ":agent_id", ":player_id"),
       (agent_is_active, ":agent_id"),
       (agent_is_alive, ":agent_id"),

--- a/module_scripts.py
+++ b/module_scripts.py
@@ -13838,8 +13838,6 @@ scripts.extend([
 
     (assign, ":test_passed", 0),
     (try_begin),
-      (player_get_is_muted, ":is_muted", ":player_id"),
-      (this_or_next|eq, ":is_muted", 0),
       (neg|multiplayer_is_server),
       (player_get_agent_id, ":agent_id", ":player_id"),
       (agent_is_active, ":agent_id"),


### PR DESCRIPTION
This needs testing and I think it will work, but we sure you want this?

It will prevent admins and players from preventing people spamming animations, which may become annoying.